### PR TITLE
use testbldr to get individual test execution

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -11,7 +11,7 @@ links = [
 
 [dependencies]
 gleam_stdlib = "~> 0.33"
-testbldr = "~> 0.2"
+testbldr = "~> 0.3"
 
 [dev-dependencies]
 simplifile = "~> 0.3"

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,8 +11,7 @@ links = [
 
 [dependencies]
 gleam_stdlib = "~> 0.33"
+testbldr = "~> 0.2"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
 simplifile = "~> 0.3"
-filepath = "~> 0.1"

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,7 +11,7 @@ links = [
 
 [dependencies]
 gleam_stdlib = "~> 0.33"
-testbldr = "~> 0.3"
 
 [dev-dependencies]
 simplifile = "~> 0.3"
+testbldr = "~> 0.3"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,15 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_community_ansi", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8B5A9677BC5A2738712BBAF2BA289B1D8195FDF962BBC769569976AD5E9794E1" },
+  { name = "gleam_community_ansi", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_colour"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8B5A9677BC5A2738712BBAF2BA289B1D8195FDF962BBC769569976AD5E9794E1" },
   { name = "gleam_community_colour", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "036C206886AFB9F153C552700A7A0B4D2864E3BC96A20C77E5F34A013C051BE3" },
   { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
   { name = "gleam_stdlib", version = "0.33.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3CEAD7B153D896499C78390B22CC968620C27500C922AED3A5DD7B536F922B25" },
   { name = "simplifile", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "8F3C94B83F691CCFACD784A4D7C1F7E5A0437D93341549B908EE3B32E3477447" },
-  { name = "testbldr", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_ansi", "gleam_erlang"], otp_app = "testbldr", source = "hex", outer_checksum = "D2D46402EB835CFDA4EC6ED475810256F3C1742F1B17CA8ED4B3E705809A6CBC" },
+  { name = "testbldr", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "gleam_community_ansi"], otp_app = "testbldr", source = "hex", outer_checksum = "88E8B62A86EF7730A7C15799E098CB275C8E59E3EE5194C29626CE059D021495" },
 ]
 
 [requirements]
 gleam_stdlib = { version = "~> 0.33" }
 simplifile = { version = "~> 0.3" }
-testbldr = { version = "~> 0.2" }
+testbldr = { version = "~> 0.3" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "534E8161A0DE192A9A105EFEC34369E9FD5834BB58ED449B5ACAEE8704358588" },
+  { name = "gleam_community_ansi", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8B5A9677BC5A2738712BBAF2BA289B1D8195FDF962BBC769569976AD5E9794E1" },
+  { name = "gleam_community_colour", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "036C206886AFB9F153C552700A7A0B4D2864E3BC96A20C77E5F34A013C051BE3" },
+  { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
   { name = "gleam_stdlib", version = "0.33.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3CEAD7B153D896499C78390B22CC968620C27500C922AED3A5DD7B536F922B25" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
   { name = "simplifile", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "8F3C94B83F691CCFACD784A4D7C1F7E5A0437D93341549B908EE3B32E3477447" },
+  { name = "testbldr", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_ansi", "gleam_erlang"], otp_app = "testbldr", source = "hex", outer_checksum = "D2D46402EB835CFDA4EC6ED475810256F3C1742F1B17CA8ED4B3E705809A6CBC" },
 ]
 
 [requirements]
-filepath = { version = "~> 0.1" }
 gleam_stdlib = { version = "~> 0.33" }
-gleeunit = { version = "~> 1.0" }
 simplifile = { version = "~> 0.3" }
+testbldr = { version = "~> 0.2" }

--- a/test/jot_test.gleam
+++ b/test/jot_test.gleam
@@ -1,29 +1,20 @@
-import gleam/io
 import gleam/list
-import gleam/string
-import gleeunit
+import gleam/int
 import jot
 import jot_test/support
+import testbldr
+import testbldr/should
 
 pub fn main() {
-  gleeunit.main()
-}
-
-pub fn integration_test() {
-  let tests = support.load_example_test_cases()
-  use testcase <- list.each(tests)
-
-  let result = jot.to_html(testcase.djot)
-  case result == testcase.html {
-    True -> io.print_error(".")
-    False -> {
-      io.print_error("F")
-      io.print_error("\n\nTest failed: " <> testcase.file)
-      io.print_error("\n\nInput:\n" <> testcase.djot)
-      io.print_error("\nExpected:\n" <> string.inspect(testcase.html))
-      io.print_error("\nActual:\n" <> string.inspect(result))
-      io.print_error("\n")
-      panic as "integration test failed"
+  testbldr.demonstrate(
+    that: "Implemented cases pass",
+    with: {
+      use tests <- list.map(support.load_example_test_cases())
+      use i, tst <- list.index_map(tests)
+      use <- testbldr.named(int.to_string(i + 1) <> " in " <> tst.file)
+      tst.html
+      |> should.equal(jot.to_html(tst.djot))
     }
-  }
+    |> list.flatten,
+  )
 }

--- a/test/jot_test.gleam
+++ b/test/jot_test.gleam
@@ -14,7 +14,7 @@ pub fn main() {
       case tst.html == jot.to_html(tst.djot) {
         True -> {
           use <- testbldr.named(".")
-          testpieces.Pass
+          testpieces.Silent
         }
         False -> {
           use <- testbldr.named(int.to_string(i + 1) <> " in " <> tst.file)

--- a/test/jot_test.gleam
+++ b/test/jot_test.gleam
@@ -3,7 +3,7 @@ import gleam/int
 import jot
 import jot_test/support
 import testbldr
-import testbldr/should
+import testbldr/pieces as testpieces
 
 pub fn main() {
   testbldr.demonstrate(
@@ -11,9 +11,20 @@ pub fn main() {
     with: {
       use tests <- list.map(support.load_example_test_cases())
       use i, tst <- list.index_map(tests)
-      use <- testbldr.named(int.to_string(i + 1) <> " in " <> tst.file)
-      tst.html
-      |> should.equal(jot.to_html(tst.djot))
+      case tst.html == jot.to_html(tst.djot) {
+        True -> {
+          use <- testbldr.named(".")
+          testpieces.Pass
+        }
+        False -> {
+          use <- testbldr.named(int.to_string(i + 1) <> " in " <> tst.file)
+          let failure_msg =
+            "Input djot: " <> tst.djot <> "\n" <> "Expected html: " <> tst.html <> "\n" <> "Produced html: " <> jot.to_html(
+              tst.djot,
+            ) <> "\n"
+          testpieces.Fail(failure_msg)
+        }
+      }
     }
     |> list.flatten,
   )

--- a/test/jot_test/support.gleam
+++ b/test/jot_test/support.gleam
@@ -1,5 +1,4 @@
 import simplifile
-import filepath
 import gleam/list
 import gleam/string
 
@@ -9,11 +8,10 @@ pub type Example {
 
 const cases_directory = "test/cases"
 
-pub fn load_example_test_cases() -> List(Example) {
-  let assert Ok(tests) = simplifile.read_directory(cases_directory)
+pub fn load_example_test_cases() -> List(List(Example)) {
+  let assert Ok(tests) = simplifile.get_files(cases_directory)
   tests
-  |> list.map(filepath.join(cases_directory, _))
-  |> list.flat_map(load_and_parse_file)
+  |> list.map(load_and_parse_file)
 }
 
 fn load_and_parse_file(path: String) -> List(Example) {


### PR DESCRIPTION
Won't be offended if you don't merge this haha, but it swaps gleeunit for testbldr so you can have individual test execution / see more than one failing test case at a time.
Testbldr needs some work to be a little more composable and configurable, issues very welcome. This is what it looks like at present, (one example with the passing tests and one with some tests altered to fail)
<img width="1470" alt="Screenshot 2023-12-14 at 12 33 11 PM" src="https://github.com/lpil/jot/assets/61021968/0e3566b8-c419-414c-a53e-a053d90f798b">
<img width="1470" alt="Screenshot 2023-12-14 at 12 32 14 PM" src="https://github.com/lpil/jot/assets/61021968/49a91c51-f508-4f40-8bb3-0a8623664841">
