### PR TITLE
Fix detection of inline code endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unpublished
+
+- Fixed a bug where inline code endings would only be detected at the end of
+  the document.
+
 ## v0.5.0 - 2024-04-30
 
 - Support added for inline code with backticks.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A parser for [Djot][djot], a markdown-like language.
 
-[djot]: https://www.djot.net/
+[djot]: https://djot.net/
 
 [![Package Version](https://img.shields.io/hexpm/v/jot)](https://hex.pm/packages/jot)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/jot/)

--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -502,7 +502,7 @@ fn parse_code_content(
   case in {
     [] -> #(content, in)
     ["`", ..in] -> {
-      let #(done, content, in) = parse_code_end(in, count, 0, content)
+      let #(done, content, in) = parse_code_end(in, count, 1, content)
       case done {
         True -> #(content, in)
         False -> parse_code_content(in, count, content)
@@ -520,17 +520,9 @@ fn parse_code_end(
 ) -> #(Bool, String, Chars) {
   case in {
     [] -> #(True, content, in)
-
-    // If there's another backtick it means that this is not the close of the
-    // inline code element.
-    ["`", "`", ..in] if limit == count -> {
-      #(False, content <> string.repeat("`", limit), in)
-    }
-
-    ["`", ..in] if limit == count -> #(True, content, in)
-
     ["`", ..in] -> parse_code_end(in, limit, count + 1, content)
-    [_, ..] -> #(False, content <> string.repeat("`", count + 1), in)
+    [_, ..] if limit == count -> #(True, content, in)
+    [_, ..] -> #(False, content <> string.repeat("`", count), in)
   }
 }
 

--- a/test/cases/verbatim.test
+++ b/test/cases/verbatim.test
@@ -13,6 +13,18 @@ with a line break</code></p>
 ```
 
 ```
+Some `code` followed by other text
+.
+<p>Some <code>code</code> followed by other text</p>
+```
+
+```
+Some `code`` with an extra backtick
+.
+<p>Some <code>code`` with an extra backtick</code></p>
+```
+
+```
 Special characters: `*hi*`
 .
 <p>Special characters: <code>*hi*</code></p>


### PR DESCRIPTION
At the moment endings of inline verbatim text only get detected if there are no more characters to parse afterwards. That means that this djot input:
```
Some `code` followed by other text
```
gets rendered as:
```
Some <code>code` followed by other text</code>
```

This PR fixes that by updating `parse_code_end` to return true once we've seen exactly the required number of backticks to close the inline verbatim text, and making sure we account for the first closing backtick that gets removed in `parse_code_content`. I was originally just going to add the extra case on line 524 but it turns out that it can replace both of the other limit checking cases; instead of checking to see if we're at the limit after each backtick removed we can eagerly pop off backticks and let the final `limit == count` check determine whether to close the block or add the backticks we removed to `contents`.

Also, I noticed the link to www.djot.net in the README gives security errors in my browser (their cert doesn't cover the www subdomain) so I updated it to djot.net.