### PR TITLE
Update deprecated dict.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1 - 2024-08-14
+
+- Updated Gleam stdlib and fixed deprecation warning.
+
 ## v1.0.0 - 2024-05-25
 
 - Support added for images.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "jot"
-version = "1.0.0"
-gleam = ">= 0.33.0"
+version = "1.0.1"
+gleam = ">= 0.39.0"
 description = "A parser for Djot, a markdown-like language"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "lpil", repo = "jot" }
@@ -10,7 +10,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.33"
+gleam_stdlib = "~> 0.39"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,13 +3,13 @@
 
 packages = [
   { name = "filepath", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "FC1B1B29438A5BA6C990F8047A011430BEC0C5BA638BFAA62718C4EAEFE00435" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "simplifile", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "8F3C94B83F691CCFACD784A4D7C1F7E5A0437D93341549B908EE3B32E3477447" },
 ]
 
 [requirements]
 filepath = { version = "~> 0.1" }
-gleam_stdlib = { version = "~> 0.33" }
+gleam_stdlib = { version = "~> 0.39" }
 gleeunit = { version = "~> 1.0" }
 simplifile = { version = "~> 0.3" }

--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -17,7 +17,7 @@ fn add_attribute(
 ) -> Dict(String, String) {
   case key {
     "class" ->
-      dict.update(attributes, key, fn(previous) {
+      dict.upsert(attributes, key, fn(previous) {
         case previous {
           None -> value
           Some(previous) -> previous <> " " <> value


### PR DESCRIPTION
Jot makes use of `dict.update`, which has been deprecated in favor of `dict.upsert`.

A warning is displayed when compiling jot in a project for the first time.

Given that `dict.update` directly calls `dict.upsert` and they use the same parameters, this is a safe change.