### PR TITLE
Readme and gleam.toml minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A parser for [Djot][djot], a markdown-like language.
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/jot/)
 
 ```sh
-gleam add jot@4
+gleam add jot@5
 ```
 ```gleam
 import jot

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,7 +5,7 @@ description = "A parser for Djot, a markdown-like language"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "lpil", repo = "jot" }
 links = [
-  { title = "Djot Syntax", href = "https://djot.net/syntax" },
+  { title = "Djot Syntax", href = "https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html" },
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
 


### PR DESCRIPTION
As I was reading over the repo I noticed two minor things in the documentation: the install command was not up to date with the major release version, and the djot syntax link was broken. Let me know if I need to change anything or if this can not be merged. Cheers!