### PR TITLE
Smart replacing of hyphens and ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added smart replacing of hyphens with em/en dashes.
+- Added smart replacing of `...` with the ellipsis symbol.
 
 ## v5.0.1 - 2025-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added smart replacing of hyphens with em/en dashes.
+
 ## v5.0.1 - 2025-08-22
 
 - Fixed warning on latest gleam_stdlib.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ This project is a work in progress. So far it supports:
 - [x] Paragraphs
 - [x] Raw blocks
 - [x] Thematic breaks
+- [x] Smart replacing of hyphens with dashes

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A parser for [Djot][djot], a markdown-like language.
 ```sh
 gleam add jot@5
 ```
+
 ```gleam
 import jot
 
@@ -53,3 +54,4 @@ This project is a work in progress. So far it supports:
 - [x] Raw blocks
 - [x] Thematic breaks
 - [x] Smart replacing of hyphens with dashes
+- [x] Smart replacing of `...` with ellipsis

--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -115,7 +115,18 @@ pub fn parse(djot: String) -> Document {
       verbatim_line_end: splitter.new([" ", "\n"]),
       codeblock_language: splitter.new(["`", "\n"]),
       inline: splitter.new([
-        "\\", "_", "*", "[^", "[", "![", "$$`", "$`", "`", "\n", "--",
+        "\\",
+        "_",
+        "*",
+        "[^",
+        "[",
+        "![",
+        "$$`",
+        "$`",
+        "`",
+        "\n",
+        "--",
+        "...",
       ]),
       link_destination: splitter.new([")", "]", "\n"]),
       math_end: splitter.new(["`"]),
@@ -738,6 +749,11 @@ fn parse_inline(
         "" -> #(list.reverse(acc), "")
         text -> #(list.reverse([Text(text), ..acc]), "")
       }
+
+    #(before, "...", in) -> {
+      let text = text <> before <> "…"
+      parse_inline(in, splitters, text, acc)
+    }
 
     #(before, "--", in) -> {
       let #(count, in) = count_drop_hyphens(in, 2)

--- a/test/cases/smart.test
+++ b/test/cases/smart.test
@@ -1,0 +1,58 @@
+Two hyphens form an en-dash, three an em-dash.
+
+```
+Some dashes:  em---em
+en--en
+em --- em
+en -- en
+2--3
+.
+<p>Some dashes:  em—em
+en–en
+em — em
+en – en
+2–3</p>
+```
+
+A sequence of more than three hyphens is
+parsed as a sequence of em and/or en dashes,
+with no hyphens. If possible, a homogeneous
+sequence of dashes is used (so, 10 hyphens
+= 5 en dashes, and 9 hyphens = 3 em dashes).
+When a heterogeneous sequence must be used,
+the em dashes come first, followed by the en
+dashes, and as few en dashes as possible are
+used (so, 7 hyphens = 2 em dashes an 1 en
+dash).
+
+```
+one-
+two--
+three---
+four----
+five-----
+six------
+seven-------
+eight--------
+nine---------
+thirteen-------------.
+.
+<p>one-
+two–
+three—
+four––
+five—–
+six——
+seven—––
+eight––––
+nine———
+thirteen———––.</p>
+```
+
+Hyphens can be escaped:
+
+```
+Escaped hyphens: \-- \-\-\-.
+.
+<p>Escaped hyphens: -- ---.</p>
+```

--- a/test/cases/smart.test
+++ b/test/cases/smart.test
@@ -56,3 +56,20 @@ Escaped hyphens: \-- \-\-\-.
 .
 <p>Escaped hyphens: -- ---.</p>
 ```
+
+Three periods form an ellipsis:
+
+```
+Ellipses...and...and....
+.
+<p>Ellipses…and…and….</p>
+```
+
+Periods can be escaped if ellipsis-formation
+is not wanted:
+
+```
+No ellipses\.\.\.
+.
+<p>No ellipses...</p>
+```

--- a/test/cases_unimplemented/smart.test
+++ b/test/cases_unimplemented/smart.test
@@ -115,65 +115,6 @@ be overridden using `{` and `}`:
 <p>‘’hi‘’</p>
 ```
 
-Two hyphens form an en-dash, three an em-dash.
-
-```
-Some dashes:  em---em
-en--en
-em --- em
-en -- en
-2--3
-.
-<p>Some dashes:  em—em
-en–en
-em — em
-en – en
-2–3</p>
-```
-
-A sequence of more than three hyphens is
-parsed as a sequence of em and/or en dashes,
-with no hyphens. If possible, a homogeneous
-sequence of dashes is used (so, 10 hyphens
-= 5 en dashes, and 9 hyphens = 3 em dashes).
-When a heterogeneous sequence must be used,
-the em dashes come first, followed by the en
-dashes, and as few en dashes as possible are
-used (so, 7 hyphens = 2 em dashes an 1 en
-dash).
-
-```
-one-
-two--
-three---
-four----
-five-----
-six------
-seven-------
-eight--------
-nine---------
-thirteen-------------.
-.
-<p>one-
-two–
-three—
-four––
-five—–
-six——
-seven—––
-eight––––
-nine———
-thirteen———––.</p>
-```
-
-Hyphens can be escaped:
-
-```
-Escaped hyphens: \-- \-\-\-.
-.
-<p>Escaped hyphens: -- ---.</p>
-```
-
 Three periods form an ellipsis:
 
 ```

--- a/test/cases_unimplemented/smart.test
+++ b/test/cases_unimplemented/smart.test
@@ -114,20 +114,3 @@ be overridden using `{` and `}`:
 .
 <p>‘’hi‘’</p>
 ```
-
-Three periods form an ellipsis:
-
-```
-Ellipses...and...and....
-.
-<p>Ellipses…and…and….</p>
-```
-
-Periods can be escaped if ellipsis-formation
-is not wanted:
-
-```
-No ellipses\.\.\.
-.
-<p>No ellipses...</p>
-```


### PR DESCRIPTION
This PR implements the smart replacing rules that replace hyphens `-` with em/en dashes; and `...` with the ellipsis symbol.