### PR TITLE
Fix issue with close div parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed parsing of content after div blocks.
+
 ## v7.1.0 - 2025-10-13
 
 - Added support for auto ids for headings that have the same content as

--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -889,7 +889,6 @@ fn take_block_quote_stop_on_div_close(
     Some(size) ->
       case check_line_suitable_div_end(line, size) {
         True -> {
-          // Include the div end line in the rest so parse_div_content can detect it
           let rest_with_div_end = case rest {
             "" -> line
             _ -> line <> "\n" <> rest
@@ -1538,7 +1537,6 @@ fn search_paragraph_for_div_end(
   let #(line, rest) = slurp_to_line_end(in)
   case check_line_suitable_div_end(line, size) {
     True -> {
-      // Include the div end line in the rest so parse_div_content can detect it
       let rest_with_div_end = case rest {
         "" -> line
         _ -> line <> "\n" <> rest

--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -888,7 +888,14 @@ fn take_block_quote_stop_on_div_close(
       }
     Some(size) ->
       case check_line_suitable_div_end(line, size) {
-        True -> #(lines, rest)
+        True -> {
+          // Include the div end line in the rest so parse_div_content can detect it
+          let rest_with_div_end = case rest {
+            "" -> line
+            _ -> line <> "\n" <> rest
+          }
+          #(lines, rest_with_div_end)
+        }
         False ->
           case rest {
             "" -> #([line, ..lines], "")
@@ -1531,7 +1538,12 @@ fn search_paragraph_for_div_end(
   let #(line, rest) = slurp_to_line_end(in)
   case check_line_suitable_div_end(line, size) {
     True -> {
-      #(acc |> list.reverse |> string.join("\n"), rest)
+      // Include the div end line in the rest so parse_div_content can detect it
+      let rest_with_div_end = case rest {
+        "" -> line
+        _ -> line <> "\n" <> rest
+      }
+      #(acc |> list.reverse |> string.join("\n"), rest_with_div_end)
     }
     False -> {
       case rest {

--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -888,13 +888,7 @@ fn take_block_quote_stop_on_div_close(
       }
     Some(size) ->
       case check_line_suitable_div_end(line, size) {
-        True -> {
-          let rest_with_div_end = case rest {
-            "" -> line
-            _ -> line <> "\n" <> rest
-          }
-          #(lines, rest_with_div_end)
-        }
+        True -> #(lines, in)
         False ->
           case rest {
             "" -> #([line, ..lines], "")
@@ -1536,13 +1530,7 @@ fn search_paragraph_for_div_end(
 ) -> #(String, String) {
   let #(line, rest) = slurp_to_line_end(in)
   case check_line_suitable_div_end(line, size) {
-    True -> {
-      let rest_with_div_end = case rest {
-        "" -> line
-        _ -> line <> "\n" <> rest
-      }
-      #(acc |> list.reverse |> string.join("\n"), rest_with_div_end)
-    }
+    True -> #(acc |> list.reverse |> string.join("\n"), in)
     False -> {
       case rest {
         "" -> #([line, ..acc] |> list.reverse |> string.join("\n"), "")

--- a/test/cases/fenced_divs.test
+++ b/test/cases/fenced_divs.test
@@ -132,3 +132,27 @@ before a closing fence, the fenced div is implicitly closed.
 </code></pre>
 </div>
 ````
+
+Headings should parse correctly after a div.
+
+```
+# Title
+
+::: mobile-images
+content in div
+:::
+
+Some paragraph text.
+
+## Development
+
+More text.
+.
+<h1 id="Title">Title</h1>
+<div class="mobile-images">
+<p>content in div</p>
+</div>
+<p>Some paragraph text.</p>
+<h2 id="Development">Development</h2>
+<p>More text.</p>
+```


### PR DESCRIPTION
This PR solves https://github.com/lpil/jot/issues/38 by including the div end line in the `rest` so `parse_div_content` can detect it in the functions `take_block_quote_stop_on_div_close` and `search_paragraph_for_div_end`