### PR TITLE
Fix blockquote lazy-continuation parser hang

### DIFF
--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -1062,7 +1062,7 @@ fn take_block_quote_stop_on_div_close(
     None ->
       case rest {
         "" -> #([line, ..lines], "")
-        _ -> take_block_quote_chars(in, [line, ..lines], div_close_size)
+        _ -> take_block_quote_chars(rest, [line, ..lines], div_close_size)
       }
     Some(size) ->
       case check_line_suitable_div_end(line, size) {
@@ -1070,7 +1070,7 @@ fn take_block_quote_stop_on_div_close(
         False ->
           case rest {
             "" -> #([line, ..lines], "")
-            _ -> take_block_quote_chars(in, [line, ..lines], div_close_size)
+            _ -> take_block_quote_chars(rest, [line, ..lines], div_close_size)
           }
       }
   }

--- a/test/cases/block_quote.test
+++ b/test/cases/block_quote.test
@@ -19,6 +19,43 @@ block <em>quote</em>.</p>
 ```
 
 ```
+> wibble
+wobble
+woo
+.
+<blockquote>
+<p>wibble
+wobble
+woo</p>
+</blockquote>
+```
+
+```
+> wibble
+wobble
+> woo
+.
+<blockquote>
+<p>wibble
+wobble
+woo</p>
+</blockquote>
+```
+
+```
+> wibble
+wobble
+
+woo
+.
+<blockquote>
+<p>wibble
+wobble</p>
+</blockquote>
+<p>woo</p>
+```
+
+```
 > block
 >
 > quote

--- a/test/cases/fenced_divs.test
+++ b/test/cases/fenced_divs.test
@@ -29,6 +29,22 @@ Hi
 ```
 
 ```
+::: foo
+> A lazy block quote.
+continued once.
+continued twice.
+:::
+.
+<div class="foo">
+<blockquote>
+<p>A lazy block quote.
+continued once.
+continued twice.</p>
+</blockquote>
+</div>
+```
+
+```
 {#bar .foo}
 :::
 Hi


### PR DESCRIPTION
## Summary

- Fix a parser progress bug when collecting lazy continuation lines inside blockquotes.
- Add regression coverage for the blockquote examples from #46.
- Add coverage for the same lazy-continuation path inside a fenced div.

This addresses the blockquote lazy-continuation hang reported in #46.

Note: a later comment on #46 reports a footnote-adjacent hang. I reproduced that separately during local checking, and it appears to use a different parser path, so this PR does not claim to fix the footnote case.

## Tests

- `gleam test --target erlang`
- `gleam test --target javascript`
- `gleam format --check src test`
- `git diff --check`
