### PR TITLE
fix parsing of unterminated code blocks

### DIFF
--- a/src/jot.gleam
+++ b/src/jot.gleam
@@ -792,6 +792,7 @@ fn parse_codeblock_start(
 
     "\n" <> in if count >= 3 -> Some(#(None, count, in))
 
+    "" if count >= 3 -> Some(#(None, count, ""))
     "" -> None
     _non_empty if count >= 3 -> {
       let in = drop_spaces(in)
@@ -834,6 +835,7 @@ fn slurp_verbatim_line(
     #(before, "\n", in) -> #(acc <> before <> "\n", in)
     #("", " ", in) if indentation > 0 ->
       slurp_verbatim_line(in, indentation - 1, acc, splitters)
+    #(before, "", "") -> #(acc <> before, "")
     #(before, split, in) ->
       slurp_verbatim_line(in, indentation, acc <> before <> split, splitters)
   }
@@ -869,8 +871,16 @@ fn parse_codeblock_language(
     // A language specifier cannot contain a backtick
     #(_, "`", _) -> None
     #(a, "\n", _) if a == "" && language == "" -> Some(#(None, in))
-    #(a, "\n", in) -> Some(#(Some(language <> a), in))
+    #(a, "\n", in) -> Some(#(codeblock_language(language <> a), in))
+    #(a, "", "") -> Some(#(codeblock_language(language <> a), ""))
     _ -> Some(#(None, in))
+  }
+}
+
+fn codeblock_language(language: String) -> Option(String) {
+  case string.trim_end(language) {
+    "" -> None
+    language -> Some(language)
   }
 }
 

--- a/test/jot_test.gleam
+++ b/test/jot_test.gleam
@@ -106,3 +106,56 @@ hey hey what up
       ),
     ]
 }
+
+pub fn unterminated_codeblock_at_end_of_input_test() {
+  let document = jot.parse("```sh")
+
+  assert document.content
+    == [
+      jot.Codeblock(
+        attributes: dict.new(),
+        language: option.Some("sh"),
+        content: "",
+      ),
+    ]
+}
+
+pub fn bare_codeblock_fence_at_end_of_input_test() {
+  let document = jot.parse("```")
+
+  assert document.content
+    == [
+      jot.Codeblock(attributes: dict.new(), language: option.None, content: ""),
+    ]
+}
+
+pub fn unterminated_codeblock_language_trims_spaces_test() {
+  let with_language = jot.parse("```sh   ")
+  let without_language = jot.parse("```   ")
+
+  assert with_language.content
+    == [
+      jot.Codeblock(
+        attributes: dict.new(),
+        language: option.Some("sh"),
+        content: "",
+      ),
+    ]
+  assert without_language.content
+    == [
+      jot.Codeblock(attributes: dict.new(), language: option.None, content: ""),
+    ]
+}
+
+pub fn unterminated_codeblock_content_at_end_of_input_test() {
+  let document = jot.parse("```\nsh")
+
+  assert document.content
+    == [
+      jot.Codeblock(
+        attributes: dict.new(),
+        language: option.None,
+        content: "sh",
+      ),
+    ]
+}


### PR DESCRIPTION
The slurp_verbatim_line fix solves an infinite loop that is present. 
Without this fix running parse(```sh) loops forever.